### PR TITLE
Fix Go Module Path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mariusvanderwijden/tx-fuzz
+module github.com/MariusVanDerWijden/tx-fuzz
 
 go 1.16
 


### PR DESCRIPTION
This changes the go module path to accurate capitalize the path otherwise go mod is unable to parse it:

```
go: github.com/MariusVanDerWijden/tx-fuzz@v0.0.0-20220222104514-79320b80893a: parsing go.mod:
        module declares its path as: github.com/mariusvanderwijden/tx-fuzz
                but was required as: github.com/MariusVanDerWijden/tx-fuzz
```