### PR TITLE
fix: import formatting broke build

### DIFF
--- a/cmd/livefuzzer/addresslist.go
+++ b/cmd/livefuzzer/addresslist.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"math/big"
 
+	txfuzz "github.com/MariusVanDerWijden/tx-fuzz"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
-	txfuzz "github.com/mariusvanderwijden/tx-fuzz"
 )
 
 var (

--- a/cmd/livefuzzer/helper.go
+++ b/cmd/livefuzzer/helper.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"math/big"
 
+	txfuzz "github.com/MariusVanDerWijden/tx-fuzz"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
-	txfuzz "github.com/mariusvanderwijden/tx-fuzz"
 )
 
 func getRealBackend() (*rpc.Client, *ecdsa.PrivateKey) {

--- a/cmd/livefuzzer/main.go
+++ b/cmd/livefuzzer/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/MariusVanDerWijden/FuzzyVM/filler"
+	txfuzz "github.com/MariusVanDerWijden/tx-fuzz"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -20,7 +21,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
-	txfuzz "github.com/mariusvanderwijden/tx-fuzz"
 )
 
 var (


### PR DESCRIPTION
Looks like the last PR merge broke the build: go compains that it knows `github.com/MariusVanDerWijden/tx-fuzz` but not `github.com/mariusvanderwijden/tx-fuzz`.