### PR TITLE
Fix blob transaction sending

### DIFF
--- a/cmd/livefuzzer/addresslist.go
+++ b/cmd/livefuzzer/addresslist.go
@@ -251,13 +251,13 @@ func airdrop(value *big.Int) error {
 	var tx *types.Transaction
 	chainid, err := backend.ChainID(context.Background())
 	if err != nil {
-		fmt.Printf("could not airdrop: %v\n", err)
+		fmt.Printf("error getting chain ID; could not airdrop: %v\n", err)
 		return err
 	}
 	for _, addr := range addrs {
 		nonce, err := backend.PendingNonceAt(context.Background(), sender)
 		if err != nil {
-			fmt.Printf("could not airdrop: %v\n", err)
+			fmt.Printf("error getting pending nonce; could not airdrop: %v\n", err)
 			return err
 		}
 		to := common.HexToAddress(addr)
@@ -265,7 +265,7 @@ func airdrop(value *big.Int) error {
 		tx2 := types.NewTransaction(nonce, to, value, 21000, gp, nil)
 		signedTx, _ := types.SignTx(tx2, types.LatestSignerForChainID(chainid), sk)
 		if err := backend.SendTransaction(context.Background(), signedTx); err != nil {
-			fmt.Printf("could not airdrop: %v\n", err)
+			fmt.Printf("error sending transaction; could not airdrop: %v\n", err)
 			return err
 		}
 		tx = signedTx

--- a/cmd/livefuzzer/main.go
+++ b/cmd/livefuzzer/main.go
@@ -164,7 +164,8 @@ func SpamTransactions(N uint64, fromCorpus bool, accessList bool, seed int64) {
 			if i < len(keys)/10 {
 				SendBlobTransactions(backend, sk, f, addr, N/10, accessList) // Send blob txs with one tenth of accounts
 			} else {
-				SendBaikalTransactions(backend, sk, f, addr, N, accessList)
+
+				// SendBaikalTransactions(backend, sk, f, addr, N, accessList)
 			}
 		}(keys[i], addrs[i], f)
 	}
@@ -208,7 +209,7 @@ func SendBaikalTransactions(client *rpc.Client, key *ecdsa.PrivateKey, f *filler
 		ctx, cancel := context.WithTimeout(context.Background(), 24*time.Second)
 		defer cancel()
 		if _, err := bind.WaitMined(ctx, backend, lastTx); err != nil {
-			fmt.Printf("Wait mined failed for : %v\n", err.Error())
+			fmt.Printf("Wait mined failed for SendBaikalTransactions: %v\n", err.Error())
 		}
 	}
 }
@@ -222,6 +223,8 @@ func SendBlobTransactions(client *rpc.Client, key *ecdsa.PrivateKey, f *filler.F
 		log.Warn("Could not get chainid, using default")
 		chainid = big.NewInt(0x01000666)
 	}
+
+	fmt.Printf("sending blob transaction, key %v, addr %v", key, addr)
 
 	var lastTx *types.Transaction
 	for i := uint64(0); i < N; i++ {
@@ -250,8 +253,8 @@ func SendBlobTransactions(client *rpc.Client, key *ecdsa.PrivateKey, f *filler.F
 		lastTx = signedTx
 		time.Sleep(10 * time.Millisecond)
 	}
+	fmt.Printf("Waiting for last tx: %v", lastTx)
 	if lastTx != nil {
-		log.Info("Waiting for last tx: %v", lastTx)
 		ctx, cancel := context.WithTimeout(context.Background(), 56*time.Second)
 		defer cancel()
 		if _, err := bind.WaitMined(ctx, backend, lastTx); err != nil {

--- a/cmd/livefuzzer/main.go
+++ b/cmd/livefuzzer/main.go
@@ -208,7 +208,7 @@ func SendBaikalTransactions(client *rpc.Client, key *ecdsa.PrivateKey, f *filler
 		ctx, cancel := context.WithTimeout(context.Background(), 24*time.Second)
 		defer cancel()
 		if _, err := bind.WaitMined(ctx, backend, lastTx); err != nil {
-			fmt.Printf("Wait mined failed: %v\n", err.Error())
+			fmt.Printf("Wait mined failed for : %v\n", err.Error())
 		}
 	}
 }
@@ -251,10 +251,11 @@ func SendBlobTransactions(client *rpc.Client, key *ecdsa.PrivateKey, f *filler.F
 		time.Sleep(10 * time.Millisecond)
 	}
 	if lastTx != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 24*time.Second)
+		log.Info("Waiting for last tx: %v", lastTx)
+		ctx, cancel := context.WithTimeout(context.Background(), 56*time.Second)
 		defer cancel()
 		if _, err := bind.WaitMined(ctx, backend, lastTx); err != nil {
-			fmt.Printf("Wait mined failed: %v\n", err.Error())
+			fmt.Printf("Wait mined failed for blob transactions: %v\n", err.Error())
 		}
 	}
 }

--- a/cmd/livefuzzer/main.go
+++ b/cmd/livefuzzer/main.go
@@ -223,8 +223,6 @@ func SendBlobTransactions(client *rpc.Client, key *ecdsa.PrivateKey, f *filler.F
 		chainid = big.NewInt(0x01000666)
 	}
 
-	fmt.Printf("sending blob transaction, key %v, addr %v", key, addr)
-
 	var lastTx *types.Transaction
 	for i := uint64(0); i < N; i++ {
 		nonce, err := backend.NonceAt(context.Background(), sender, big.NewInt(-1))

--- a/cmd/livefuzzer/main.go
+++ b/cmd/livefuzzer/main.go
@@ -161,12 +161,13 @@ func SpamTransactions(N uint64, fromCorpus bool, accessList bool, seed int64) {
 		go func(key, addr string, filler *filler.Filler) {
 			defer wg.Done()
 			sk := crypto.ToECDSAUnsafe(common.FromHex(key))
-			if i < len(keys)/10 {
-				SendBlobTransactions(backend, sk, f, addr, N/10, accessList) // Send blob txs with one tenth of accounts
-			} else {
 
-				// SendBaikalTransactions(backend, sk, f, addr, N, accessList)
-			}
+			SendBlobTransactions(backend, sk, f, addr, N/10, accessList) // Send blob txs with one tenth of accounts
+			// if i < len(keys)/10 {
+			// } else {
+
+			// SendBaikalTransactions(backend, sk, f, addr, N, accessList)
+			// }
 		}(keys[i], addrs[i], f)
 	}
 	wg.Wait()


### PR DESCRIPTION
I ran into an error where no blob transactions were sent. It seems that the iterator index does not get properly captured in the go routine and the if statement to decide which type of transaction to send is always false. Introduced in 991f79a2f23aee5b48bd5e4feea0e71a4fa7fa09. 