### PR TITLE
Add Cancun timestamp

### DIFF
--- a/cmd/livefuzzer/flags.go
+++ b/cmd/livefuzzer/flags.go
@@ -43,4 +43,10 @@ var (
 		Usage: "Number of transactions send per account per block, 0 = best estimate",
 		Value: 0,
 	}
+
+	cancunTimestampFlag = &cli.Int64Flag{
+		Name:  "cancun-timestamp",
+		Usage: "Timestamp of the Cancun hardfork, to enable type-3 transactions (disable: -1)",
+		Value: -1,
+	}
 )

--- a/cmd/livefuzzer/main.go
+++ b/cmd/livefuzzer/main.go
@@ -132,21 +132,21 @@ func SpamTransactions(N uint64, fromCorpus bool, accessList bool, seed int64, ca
 
 	// Reusable closures to only get information if needed
 	var (
-		latestBlock *types.Block
-		client      *ethclient.Client
+		latestHeader *types.Header
+		client       *ethclient.Client
 	)
-	getLatestBlock := func() *types.Block {
-		if latestBlock == nil {
+	getLatestHeader := func() *types.Header {
+		if latestHeader == nil {
 			var err error
 			if client == nil {
 				client = ethclient.NewClient(backend)
 			}
-			latestBlock, err = client.BlockByNumber(context.Background(), nil)
-			if err != nil || latestBlock == nil {
+			latestHeader, err = client.HeaderByNumber(context.Background(), nil)
+			if err != nil || latestHeader == nil {
 				panic(err)
 			}
 		}
-		return latestBlock
+		return latestHeader
 	}
 	checkForkTimestamp := func(forkTimestamp int64) bool {
 		if forkTimestamp == -1 {
@@ -155,12 +155,12 @@ func SpamTransactions(N uint64, fromCorpus bool, accessList bool, seed int64, ca
 		if forkTimestamp == 0 {
 			return true
 		}
-		return getLatestBlock().Time() >= uint64(forkTimestamp)
+		return getLatestHeader().Time >= uint64(forkTimestamp)
 	}
 
 	// Setup N
 	if N == 0 {
-		txPerBlock := getLatestBlock().GasLimit() / uint64(defaultGas)
+		txPerBlock := getLatestHeader().GasLimit / uint64(defaultGas)
 		txPerAccount := txPerBlock / uint64(len(keys))
 		N = txPerAccount
 		if N == 0 {


### PR DESCRIPTION
Currently the `spam` subcommand fails if started on a local testnet where cancun has not been reached:
```
marioevz@hive-simulations:~/Development/Eth/mock-builder$ kurtosis service logs eth2 transaction-spammer
No seed provided, creating one
Spamming 25 transactions per account on 10 accounts with seed: 0x27700f12be15d37
panic: transaction type not supported: type 3 rejected, pool not yet in Cancun

goroutine 9 [running]:
main.SendBlobTransactions(0xc0003aa120, 0x20?, 0x40?, {0xe487b8, 0x2a}, 0x2, 0x80?)
        /build/cmd/livefuzzer/main.go:248 +0x733
main.SpamTransactions.func1({0xe58dd9?, 0xc000414650?}, {0xe487b8, 0x2a}, 0x835366?, 0x0)
        /build/cmd/livefuzzer/main.go:165 +0x114
created by main.SpamTransactions
        /build/cmd/livefuzzer/main.go:161 +0x487
```

This PR adds a `--cancun-timestamp` flag to specify when to start sending type-3 transactions.