### PR TITLE
cmd/livefuzzer: split blob and basic fuzzing commands

### DIFF
--- a/cmd/livefuzzer/basic.go
+++ b/cmd/livefuzzer/basic.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	crand "crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/MariusVanDerWijden/FuzzyVM/filler"
+	txfuzz "github.com/MariusVanDerWijden/tx-fuzz"
+	"github.com/MariusVanDerWijden/tx-fuzz/mutator"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+func setup(backend *rpc.Client, seed int64, N uint64) (int64, *mutator.Mutator, uint64) {
+	// Setup seed
+	if seed == 0 {
+		fmt.Println("No seed provided, creating one")
+		rnd := make([]byte, 8)
+		crand.Read(rnd)
+		s := int64(binary.BigEndian.Uint64(rnd))
+		seed = s
+	}
+
+	// Setup N
+	client := ethclient.NewClient(backend)
+	header, err := client.HeaderByNumber(context.Background(), nil)
+	if err != nil {
+		panic(err)
+	}
+	if N == 0 {
+		txPerBlock := header.GasLimit / uint64(defaultGas)
+		txPerAccount := txPerBlock / uint64(len(keys))
+		N = txPerAccount
+		if N == 0 {
+			N = 1
+		}
+	}
+
+	mut := mutator.NewMutator(rand.New(rand.NewSource(seed)))
+	return seed, mut, N
+}
+
+func SpamBasicTransactions(N uint64, fromCorpus bool, accessList bool, seed int64) {
+	backend, _, err := getRealBackend()
+	if err != nil {
+		log.Warn("Could not get backend", "error", err)
+		return
+	}
+
+	// Set up the randomness
+	random := make([]byte, 10000)
+	seed, mut, N := setup(backend, seed, N)
+
+	fmt.Printf("Spamming %v transactions per account on %v accounts with seed: 0x%x\n", N, len(keys), seed)
+	// Now let everyone spam baikal transactions
+	var wg sync.WaitGroup
+	wg.Add(len(keys))
+	for i := range keys {
+		var f *filler.Filler
+		if fromCorpus {
+			elem := corpus[rand.Int31n(int32(len(corpus)))]
+			mut.MutateBytes(&elem)
+			f = filler.NewFiller(elem)
+		} else {
+			// Use lower entropy randomness for filler
+			mut.MutateBytes(&random)
+			f = filler.NewFiller(random)
+		}
+		// Start a fuzzing thread
+		go func(key, addr string, filler *filler.Filler) {
+			defer wg.Done()
+			sk := crypto.ToECDSAUnsafe(common.FromHex(key))
+			SendBasicTransactions(backend, sk, f, addr, N, accessList)
+		}(keys[i], addrs[i], f)
+	}
+	wg.Wait()
+}
+
+func SendBasicTransactions(client *rpc.Client, key *ecdsa.PrivateKey, f *filler.Filler, addr string, N uint64, al bool) {
+	backend := ethclient.NewClient(client)
+
+	sender := common.HexToAddress(addr)
+	chainID, err := backend.ChainID(context.Background())
+	if err != nil {
+		log.Warn("Could not get chainID, using default")
+		chainID = big.NewInt(0x01000666)
+	}
+
+	var lastTx *types.Transaction
+	for i := uint64(0); i < N; i++ {
+		nonce, err := backend.NonceAt(context.Background(), sender, big.NewInt(-1))
+		if err != nil {
+			log.Warn("Could not get nonce: %v", nonce)
+			continue
+		}
+		tx, err := txfuzz.RandomValidTx(client, f, sender, nonce, nil, nil, al)
+		if err != nil {
+			log.Warn("Could not create valid tx: %v", nonce)
+			continue
+		}
+		signedTx, err := types.SignTx(tx, types.NewCancunSigner(chainID), key)
+		if err != nil {
+			panic(err)
+		}
+		if err := backend.SendTransaction(context.Background(), signedTx); err != nil {
+			log.Warn("Could not submit transaction: %v", err)
+			continue
+		}
+		lastTx = signedTx
+		time.Sleep(10 * time.Millisecond)
+	}
+	if lastTx != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 24*time.Second)
+		defer cancel()
+		if _, err := bind.WaitMined(ctx, backend, lastTx); err != nil {
+			fmt.Printf("Wait mined failed for SendBaikalTransactions: %v\n", err.Error())
+		}
+	}
+}

--- a/cmd/livefuzzer/blob.go
+++ b/cmd/livefuzzer/blob.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/MariusVanDerWijden/FuzzyVM/filler"
+	txfuzz "github.com/MariusVanDerWijden/tx-fuzz"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+func SpamBlobTransactions(N uint64, fromCorpus bool, accessList bool, seed int64) {
+	backend, _, err := getRealBackend()
+	if err != nil {
+		log.Warn("Could not get backend", "error", err)
+		return
+	}
+	// Set up the randomness
+	random := make([]byte, 10000)
+	seed, mut, N := setup(backend, seed, N)
+
+	fmt.Printf("Spamming %v blob transactions per account on %v accounts with seed: 0x%x\n", N, len(keys), seed)
+	// Now let everyone spam blob transactions
+	var wg sync.WaitGroup
+	wg.Add(len(keys))
+	for i := range keys {
+		var f *filler.Filler
+		if fromCorpus {
+			elem := corpus[rand.Int31n(int32(len(corpus)))]
+			mut.MutateBytes(&elem)
+			f = filler.NewFiller(elem)
+		} else {
+			// Use lower entropy randomness for filler
+			mut.MutateBytes(&random)
+			f = filler.NewFiller(random)
+		}
+		// Start a fuzzing thread
+		go func(key, addr string, filler *filler.Filler) {
+			defer wg.Done()
+			sk := crypto.ToECDSAUnsafe(common.FromHex(key))
+			SendBlobTransactions(backend, sk, f, addr, N, accessList)
+		}(keys[i], addrs[i], f)
+	}
+	wg.Wait()
+}
+
+func SendBlobTransactions(client *rpc.Client, key *ecdsa.PrivateKey, f *filler.Filler, addr string, N uint64, al bool) {
+	backend := ethclient.NewClient(client)
+
+	sender := common.HexToAddress(addr)
+	chainID, err := backend.ChainID(context.Background())
+	if err != nil {
+		log.Warn("Could not get chainID, using default")
+		chainID = big.NewInt(0x01000666)
+	}
+
+	var lastTx *types.Transaction
+	for i := uint64(0); i < N; i++ {
+		nonce, err := backend.NonceAt(context.Background(), sender, big.NewInt(-1))
+		if err != nil {
+			log.Warn("Could not get nonce: %v", nonce)
+			continue
+		}
+		tx, err := txfuzz.RandomBlobTx(client, f, sender, nonce, nil, nil, al)
+		if err != nil {
+			log.Warn("Could not create valid tx: %v", nonce)
+			continue
+		}
+		signedTx, err := types.SignTx(tx.Transaction, types.NewCancunSigner(chainID), key)
+		if err != nil {
+			panic(err)
+		}
+		tx.Transaction = signedTx
+		rlpData, err := tx.MarshalBinary()
+		if err != nil {
+			panic(err)
+		}
+		if err := client.CallContext(context.Background(), nil, "eth_sendRawTransaction", hexutil.Encode(rlpData)); err != nil {
+			panic(err)
+		}
+		lastTx = signedTx
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if lastTx != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 24*time.Second)
+		defer cancel()
+		if _, err := bind.WaitMined(ctx, backend, lastTx); err != nil {
+			fmt.Printf("Wait mined failed for blob transactions: %v\n", err.Error())
+		}
+	}
+}

--- a/cmd/livefuzzer/flags.go
+++ b/cmd/livefuzzer/flags.go
@@ -43,10 +43,4 @@ var (
 		Usage: "Number of transactions send per account per block, 0 = best estimate",
 		Value: 0,
 	}
-
-	cancunTimestampFlag = &cli.Int64Flag{
-		Name:  "cancun-timestamp",
-		Usage: "Timestamp of the Cancun hardfork, to enable type-3 transactions (disable: -1)",
-		Value: -1,
-	}
 )

--- a/cmd/livefuzzer/main.go
+++ b/cmd/livefuzzer/main.go
@@ -1,29 +1,18 @@
 package main
 
 import (
-	"context"
-	"crypto/ecdsa"
-	crand "crypto/rand"
-	"encoding/binary"
 	"fmt"
 	"math/big"
-	"math/rand"
 	"os"
 	"sync"
 	"time"
 
-	"github.com/MariusVanDerWijden/FuzzyVM/filler"
 	txfuzz "github.com/MariusVanDerWijden/tx-fuzz"
-	"github.com/MariusVanDerWijden/tx-fuzz/mutator"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/urfave/cli/v2"
 )
 
@@ -46,7 +35,7 @@ var airdropCommand = &cli.Command{
 var spamCommand = &cli.Command{
 	Name:   "spam",
 	Usage:  "Send spam transactions",
-	Action: runSpam,
+	Action: runBasicSpam,
 	Flags: []cli.Flag{
 		skFlag,
 		seedFlag,
@@ -54,7 +43,20 @@ var spamCommand = &cli.Command{
 		corpusFlag,
 		rpcFlag,
 		txCountFlag,
-		cancunTimestampFlag,
+	},
+}
+
+var blobSpamCommand = &cli.Command{
+	Name:   "blobs",
+	Usage:  "Send blob spam transactions",
+	Action: runBlobSpam,
+	Flags: []cli.Flag{
+		skFlag,
+		seedFlag,
+		noALFlag,
+		corpusFlag,
+		rpcFlag,
+		txCountFlag,
 	},
 }
 
@@ -93,6 +95,7 @@ func initApp() *cli.App {
 	app.Commands = []*cli.Command{
 		airdropCommand,
 		spamCommand,
+		blobSpamCommand,
 		unstuckCommand,
 		sendCommand,
 		createCommand,
@@ -107,184 +110,6 @@ func main() {
 	if err := app.Run(os.Args); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
-	}
-}
-
-func SpamTransactions(N uint64, fromCorpus bool, accessList bool, seed int64, cancunTs int64) {
-	backend, _, err := getRealBackend()
-	if err != nil {
-		log.Warn("Could not get backend", "error", err)
-		return
-	}
-	// Setup seed
-	var src *rand.Rand
-	if seed == 0 {
-		fmt.Println("No seed provided, creating one")
-		rnd := make([]byte, 8)
-		crand.Read(rnd)
-		s := int64(binary.BigEndian.Uint64(rnd))
-		seed = s
-	}
-	src = rand.New(rand.NewSource(seed))
-	mut := mutator.NewMutator(src)
-	// Set up the randomness
-	random := make([]byte, 10000)
-
-	// Reusable closures to only get information if needed
-	var (
-		latestHeader *types.Header
-		client       *ethclient.Client
-	)
-	getLatestHeader := func() *types.Header {
-		if latestHeader == nil {
-			var err error
-			if client == nil {
-				client = ethclient.NewClient(backend)
-			}
-			latestHeader, err = client.HeaderByNumber(context.Background(), nil)
-			if err != nil || latestHeader == nil {
-				panic(err)
-			}
-		}
-		return latestHeader
-	}
-	checkForkTimestamp := func(forkTimestamp int64) bool {
-		if forkTimestamp == -1 {
-			return false
-		}
-		if forkTimestamp == 0 {
-			return true
-		}
-		return getLatestHeader().Time >= uint64(forkTimestamp)
-	}
-
-	// Setup N
-	if N == 0 {
-		txPerBlock := getLatestHeader().GasLimit / uint64(defaultGas)
-		txPerAccount := txPerBlock / uint64(len(keys))
-		N = txPerAccount
-		if N == 0 {
-			N = 1
-		}
-	}
-	// Check Forks
-	cancunEnabled := checkForkTimestamp(cancunTs)
-
-	fmt.Printf("Spamming %v transactions per account on %v accounts with seed: 0x%x\n", N, len(keys), seed)
-	// Now let everyone spam baikal transactions
-	var wg sync.WaitGroup
-	wg.Add(len(keys))
-	for i := range keys {
-		var f *filler.Filler
-		if fromCorpus {
-			elem := corpus[rand.Int31n(int32(len(corpus)))]
-			mut.MutateBytes(&elem)
-			f = filler.NewFiller(elem)
-		} else {
-			// Use lower entropy randomness for filler
-			mut.MutateBytes(&random)
-			f = filler.NewFiller(random)
-		}
-		// Start a fuzzing thread
-		go func(key, addr string, filler *filler.Filler, index int) {
-			defer wg.Done()
-			sk := crypto.ToECDSAUnsafe(common.FromHex(key))
-			if cancunEnabled && index < len(keys)/10 {
-				SendBlobTransactions(backend, sk, f, addr, N/10, accessList) // Send blob txs with one tenth of accounts
-			} else {
-				SendBaikalTransactions(backend, sk, f, addr, N, accessList)
-			}
-		}(keys[i], addrs[i], f, i)
-	}
-	wg.Wait()
-}
-
-func SendBaikalTransactions(client *rpc.Client, key *ecdsa.PrivateKey, f *filler.Filler, addr string, N uint64, al bool) {
-	backend := ethclient.NewClient(client)
-
-	sender := common.HexToAddress(addr)
-	chainid, err := backend.ChainID(context.Background())
-	if err != nil {
-		log.Warn("Could not get chainid, using default")
-		chainid = big.NewInt(0x01000666)
-	}
-
-	var lastTx *types.Transaction
-	for i := uint64(0); i < N; i++ {
-		nonce, err := backend.NonceAt(context.Background(), sender, big.NewInt(-1))
-		if err != nil {
-			log.Warn("Could not get nonce: %v", nonce)
-			continue
-		}
-		tx, err := txfuzz.RandomValidTx(client, f, sender, nonce, nil, nil, al)
-		if err != nil {
-			log.Warn("Could not create valid tx: %v", nonce)
-			continue
-		}
-		signedTx, err := types.SignTx(tx, types.NewCancunSigner(chainid), key)
-		if err != nil {
-			panic(err)
-		}
-		if err := backend.SendTransaction(context.Background(), signedTx); err != nil {
-			log.Warn("Could not submit transaction: %v", err)
-			continue
-		}
-		lastTx = signedTx
-		time.Sleep(10 * time.Millisecond)
-	}
-	if lastTx != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 24*time.Second)
-		defer cancel()
-		if _, err := bind.WaitMined(ctx, backend, lastTx); err != nil {
-			fmt.Printf("Wait mined failed for SendBaikalTransactions: %v\n", err.Error())
-		}
-	}
-}
-
-func SendBlobTransactions(client *rpc.Client, key *ecdsa.PrivateKey, f *filler.Filler, addr string, N uint64, al bool) {
-	backend := ethclient.NewClient(client)
-
-	sender := common.HexToAddress(addr)
-	chainid, err := backend.ChainID(context.Background())
-	if err != nil {
-		log.Warn("Could not get chainid, using default")
-		chainid = big.NewInt(0x01000666)
-	}
-
-	var lastTx *types.Transaction
-	for i := uint64(0); i < N; i++ {
-		nonce, err := backend.NonceAt(context.Background(), sender, big.NewInt(-1))
-		if err != nil {
-			log.Warn("Could not get nonce: %v", nonce)
-			continue
-		}
-		tx, err := txfuzz.RandomBlobTx(client, f, sender, nonce, nil, nil, al)
-		if err != nil {
-			log.Warn("Could not create valid tx: %v", nonce)
-			continue
-		}
-		signedTx, err := types.SignTx(tx.Transaction, types.NewCancunSigner(chainid), key)
-		if err != nil {
-			panic(err)
-		}
-		tx.Transaction = signedTx
-		rlpData, err := tx.MarshalBinary()
-		if err != nil {
-			panic(err)
-		}
-		if err := client.CallContext(context.Background(), nil, "eth_sendRawTransaction", hexutil.Encode(rlpData)); err != nil {
-			panic(err)
-		}
-		lastTx = signedTx
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	if lastTx != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 24*time.Second)
-		defer cancel()
-		if _, err := bind.WaitMined(ctx, backend, lastTx); err != nil {
-			fmt.Printf("Wait mined failed for blob transactions: %v\n", err.Error())
-		}
 	}
 }
 
@@ -341,11 +166,10 @@ func runAirdrop(c *cli.Context) error {
 	return nil
 }
 
-func runSpam(c *cli.Context) error {
+func spam(c *cli.Context, basic bool) error {
 	setupDefaults(c)
 	noAL := c.Bool(noALFlag.Name)
 	seed := c.Int64(seedFlag.Name)
-	cancunTs := c.Int64(cancunTimestampFlag.Name)
 	txPerAccount := c.Int(txCountFlag.Name)
 	// Setup corpus if needed
 	if corpusFile := c.String(corpusFlag.Name); corpusFile != "" {
@@ -364,9 +188,21 @@ func runSpam(c *cli.Context) error {
 		if err := airdrop(airdropValue); err != nil {
 			return err
 		}
-		SpamTransactions(uint64(txPerAccount), false, !noAL, seed, cancunTs)
+		if basic {
+			SpamBasicTransactions(uint64(txPerAccount), false, !noAL, seed)
+		} else {
+			SpamBlobTransactions(uint64(txPerAccount), false, !noAL, seed)
+		}
 		time.Sleep(12 * time.Second)
 	}
+}
+
+func runBasicSpam(c *cli.Context) error {
+	return spam(c, true)
+}
+
+func runBlobSpam(c *cli.Context) error {
+	return spam(c, false)
 }
 
 func runUnstuck(c *cli.Context) error {


### PR DESCRIPTION
Partly reverts the cancuntime command in order to split the blob and basic fuzzing commands.
I don't think its good to basically busy wait in the program for a certain condition to hit until we can start spamming. These kind of setups should be done outside of the program.
I do see a need to force only blob and only basic transactions though
cc @parithosh @marioevz 