### PR TITLE
cmd/livefuzzer: big refactor of the livefuzzer

### DIFF
--- a/cmd/livefuzzer/basic.go
+++ b/cmd/livefuzzer/basic.go
@@ -3,96 +3,22 @@ package main
 import (
 	"context"
 	"crypto/ecdsa"
-	crand "crypto/rand"
-	"encoding/binary"
 	"fmt"
 	"math/big"
-	"math/rand"
-	"sync"
 	"time"
 
 	"github.com/MariusVanDerWijden/FuzzyVM/filler"
 	txfuzz "github.com/MariusVanDerWijden/tx-fuzz"
-	"github.com/MariusVanDerWijden/tx-fuzz/mutator"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rpc"
 )
 
-func setup(backend *rpc.Client, seed int64, N uint64) (int64, *mutator.Mutator, uint64) {
-	// Setup seed
-	if seed == 0 {
-		fmt.Println("No seed provided, creating one")
-		rnd := make([]byte, 8)
-		crand.Read(rnd)
-		s := int64(binary.BigEndian.Uint64(rnd))
-		seed = s
-	}
-
-	// Setup N
-	client := ethclient.NewClient(backend)
-	header, err := client.HeaderByNumber(context.Background(), nil)
-	if err != nil {
-		panic(err)
-	}
-	if N == 0 {
-		txPerBlock := header.GasLimit / uint64(defaultGas)
-		txPerAccount := txPerBlock / uint64(len(keys))
-		N = txPerAccount
-		if N == 0 {
-			N = 1
-		}
-	}
-
-	mut := mutator.NewMutator(rand.New(rand.NewSource(seed)))
-	return seed, mut, N
-}
-
-func SpamBasicTransactions(N uint64, fromCorpus bool, accessList bool, seed int64) {
-	backend, _, err := getRealBackend()
-	if err != nil {
-		log.Warn("Could not get backend", "error", err)
-		return
-	}
-
-	// Set up the randomness
-	seed, mut, N := setup(backend, seed, N)
-	random := make([]byte, 10000)
-	mut.FillBytes(&random)
-
-	fmt.Printf("Spamming %v transactions per account on %v accounts with seed: 0x%x\n", N, len(keys), seed)
-	// Now let everyone spam baikal transactions
-	var wg sync.WaitGroup
-	wg.Add(len(keys))
-	for i := range keys {
-		var f *filler.Filler
-		if fromCorpus {
-			elem := corpus[rand.Int31n(int32(len(corpus)))]
-			mut.MutateBytes(&elem)
-			f = filler.NewFiller(elem)
-		} else {
-			// Use lower entropy randomness for filler
-			mut.MutateBytes(&random)
-			f = filler.NewFiller(random)
-		}
-		// Start a fuzzing thread
-		go func(key, addr string, filler *filler.Filler) {
-			defer wg.Done()
-			sk := crypto.ToECDSAUnsafe(common.FromHex(key))
-			SendBasicTransactions(backend, sk, f, addr, N, accessList)
-		}(keys[i], addrs[i], f)
-	}
-	wg.Wait()
-}
-
-func SendBasicTransactions(client *rpc.Client, key *ecdsa.PrivateKey, f *filler.Filler, addr string, N uint64, al bool) {
-	backend := ethclient.NewClient(client)
-
-	sender := common.HexToAddress(addr)
+func SendBasicTransactions(config *Config, key *ecdsa.PrivateKey, f *filler.Filler) {
+	backend := ethclient.NewClient(config.backend)
+	sender := crypto.PubkeyToAddress(key.PublicKey)
 	chainID, err := backend.ChainID(context.Background())
 	if err != nil {
 		log.Warn("Could not get chainID, using default")
@@ -100,13 +26,13 @@ func SendBasicTransactions(client *rpc.Client, key *ecdsa.PrivateKey, f *filler.
 	}
 
 	var lastTx *types.Transaction
-	for i := uint64(0); i < N; i++ {
+	for i := uint64(0); i < config.n; i++ {
 		nonce, err := backend.NonceAt(context.Background(), sender, big.NewInt(-1))
 		if err != nil {
 			log.Warn("Could not get nonce: %v", nonce)
 			continue
 		}
-		tx, err := txfuzz.RandomValidTx(client, f, sender, nonce, nil, nil, al)
+		tx, err := txfuzz.RandomValidTx(config.backend, f, sender, nonce, nil, nil, config.accessList)
 		if err != nil {
 			log.Warn("Could not create valid tx: %v", nonce)
 			continue

--- a/cmd/livefuzzer/config.go
+++ b/cmd/livefuzzer/config.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	crand "crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"os"
+
+	txfuzz "github.com/MariusVanDerWijden/tx-fuzz"
+	"github.com/MariusVanDerWijden/tx-fuzz/mutator"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/urfave/cli/v2"
+)
+
+type Config struct {
+	backend *rpc.Client // connection to the rpc provider
+
+	n          uint64              // number of transactions send per account
+	faucet     *ecdsa.PrivateKey   // private key of the faucet account
+	keys       []*ecdsa.PrivateKey // private keys of accounts
+	corpus     [][]byte            // optional corpus to use elements from
+	accessList bool                // whether to create accesslist transactions
+	gasLimit   uint64              // gas limit per transaction
+
+	seed int64            // seed used for generating randomness
+	mut  *mutator.Mutator // Mutator based on the seed
+}
+
+func NewConfigFromContext(c *cli.Context) (*Config, error) {
+	// Setup RPC
+	rpcAddr := c.String(rpcFlag.Name)
+	backend, err := rpc.Dial(rpcAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Setup faucet
+	faucet := crypto.ToECDSAUnsafe(common.FromHex(txfuzz.SK))
+	if sk := c.String(skFlag.Name); sk != "" {
+		faucet, err = crypto.ToECDSA(common.FromHex(sk))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Setup Keys
+	var keys []*ecdsa.PrivateKey
+	nKeys := c.Int(countFlag.Name)
+	if nKeys == 0 || nKeys > len(staticKeys) {
+		fmt.Printf("Sanitizing count flag from %v to %v\n", nKeys, len(staticKeys))
+		nKeys = len(staticKeys)
+	}
+	for i := 0; i < nKeys; i++ {
+		keys = append(keys, crypto.ToECDSAUnsafe(common.FromHex(staticKeys[i])))
+	}
+
+	// Setup gasLimit
+	gasLimit := c.Int(gasLimitFlag.Name)
+
+	// Setup N
+	N := c.Int(txCountFlag.Name)
+	if N == 0 {
+		N, err = setupN(backend, len(keys), gasLimit)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Setup seed
+	seed := c.Int64(seedFlag.Name)
+	if seed == 0 {
+		fmt.Println("No seed provided, creating one")
+		rnd := make([]byte, 8)
+		crand.Read(rnd)
+		seed = int64(binary.BigEndian.Uint64(rnd))
+	}
+
+	// Setup Mutator
+	mut := mutator.NewMutator(rand.New(rand.NewSource(seed)))
+
+	// Setup corpus
+	var corpus [][]byte
+	if corpusFile := c.String(corpusFlag.Name); corpusFile != "" {
+		corpus, err = readCorpusElements(corpusFile)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &Config{
+		backend:    backend,
+		n:          uint64(N),
+		faucet:     faucet,
+		accessList: !c.Bool(noALFlag.Name),
+		gasLimit:   uint64(gasLimit),
+		seed:       seed,
+		keys:       keys,
+		corpus:     corpus,
+		mut:        mut,
+	}, nil
+}
+
+func setupN(backend *rpc.Client, keys int, gasLimit int) (int, error) {
+	client := ethclient.NewClient(backend)
+	header, err := client.HeaderByNumber(context.Background(), nil)
+	if err != nil {
+		return 0, err
+	}
+	txPerBlock := int(header.GasLimit / uint64(gasLimit))
+	txPerAccount := txPerBlock / keys
+	if txPerAccount == 0 {
+		return 1, nil
+	}
+	return txPerAccount, nil
+}
+
+func readCorpusElements(path string) ([][]byte, error) {
+	stats, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	corpus := make([][]byte, 0, len(stats))
+	for _, file := range stats {
+		b, err := os.ReadFile(fmt.Sprintf("%v/%v", path, file.Name()))
+		if err != nil {
+			return nil, err
+		}
+		corpus = append(corpus, b)
+	}
+	return corpus, nil
+}

--- a/cmd/livefuzzer/flags.go
+++ b/cmd/livefuzzer/flags.go
@@ -27,8 +27,8 @@ var (
 	}
 
 	countFlag = &cli.IntFlag{
-		Name:  "count",
-		Usage: "Count of addresses to create",
+		Name:  "accounts",
+		Usage: "Count of accounts to send transactions from",
 		Value: 100,
 	}
 
@@ -42,5 +42,22 @@ var (
 		Name:  "txcount",
 		Usage: "Number of transactions send per account per block, 0 = best estimate",
 		Value: 0,
+	}
+
+	gasLimitFlag = &cli.IntFlag{
+		Name:  "gaslimit",
+		Usage: "Gas limit used for transactions",
+		Value: 100_000,
+	}
+
+	spamFlags = []cli.Flag{
+		skFlag,
+		seedFlag,
+		noALFlag,
+		corpusFlag,
+		rpcFlag,
+		txCountFlag,
+		countFlag,
+		gasLimitFlag,
 	}
 )

--- a/cmd/livefuzzer/helper.go
+++ b/cmd/livefuzzer/helper.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
-func sendTx(sk *ecdsa.PrivateKey, backend *ethclient.Client, to common.Address, value *big.Int) error {
+func SendTx(sk *ecdsa.PrivateKey, backend *ethclient.Client, to common.Address, value *big.Int) error {
 	sender := common.HexToAddress(txfuzz.ADDR)
 	nonce, err := backend.PendingNonceAt(context.Background(), sender)
 	if err != nil {

--- a/cmd/livefuzzer/helper.go
+++ b/cmd/livefuzzer/helper.go
@@ -11,19 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/rpc"
 )
-
-func getRealBackend() (*rpc.Client, *ecdsa.PrivateKey, error) {
-	// eth.sendTransaction({from:personal.listAccounts[0], to:"0xb02A2EdA1b317FBd16760128836B0Ac59B560e9D", value: "100000000000000"})
-
-	sk := crypto.ToECDSAUnsafe(common.FromHex(txfuzz.SK))
-	if crypto.PubkeyToAddress(sk.PublicKey).Hex() != txfuzz.ADDR {
-		panic(fmt.Sprintf("wrong address want %s got %s", crypto.PubkeyToAddress(sk.PublicKey).Hex(), txfuzz.ADDR))
-	}
-	cl, err := rpc.Dial(address)
-	return cl, sk, err
-}
 
 func sendTx(sk *ecdsa.PrivateKey, backend *ethclient.Client, to common.Address, value *big.Int) error {
 	sender := common.HexToAddress(txfuzz.ADDR)
@@ -42,7 +30,8 @@ func sendTx(sk *ecdsa.PrivateKey, backend *ethclient.Client, to common.Address, 
 	return backend.SendTransaction(context.Background(), signedTx)
 }
 
-func unstuck(sk *ecdsa.PrivateKey, backend *ethclient.Client, sender, to common.Address, value, gasPrice *big.Int) error {
+func unstuck(sk *ecdsa.PrivateKey, backend *ethclient.Client, to common.Address, value, gasPrice *big.Int) error {
+	sender := crypto.PubkeyToAddress(sk.PublicKey)
 	blocknumber, err := backend.BlockNumber(context.Background())
 	if err != nil {
 		return err

--- a/cmd/livefuzzer/main.go
+++ b/cmd/livefuzzer/main.go
@@ -15,10 +15,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var (
-	defaultGas = 100000
-)
-
 var airdropCommand = &cli.Command{
 	Name:   "airdrop",
 	Usage:  "Airdrops to a list of accounts",

--- a/cmd/livefuzzer/spam.go
+++ b/cmd/livefuzzer/spam.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"math/rand"
+	"sync"
+
+	"github.com/MariusVanDerWijden/FuzzyVM/filler"
+)
+
+type Spam func(*Config, *ecdsa.PrivateKey, *filler.Filler)
+
+func SpamTransactions(config *Config, fun Spam) {
+	fmt.Printf("Spamming %v transactions per account on %v accounts with seed: 0x%x\n", config.n, len(config.keys), config.seed)
+
+	var wg sync.WaitGroup
+	wg.Add(len(config.keys))
+	for _, key := range config.keys {
+		// Setup randomness uniquely per key
+		random := make([]byte, 10000)
+		config.mut.FillBytes(&random)
+
+		var f *filler.Filler
+		if len(config.corpus) != 0 {
+			elem := config.corpus[rand.Int31n(int32(len(config.corpus)))]
+			config.mut.MutateBytes(&elem)
+			f = filler.NewFiller(elem)
+		} else {
+			// Use lower entropy randomness for filler
+			config.mut.MutateBytes(&random)
+			f = filler.NewFiller(random)
+		}
+		// Start a fuzzing thread
+		go func(key *ecdsa.PrivateKey, filler *filler.Filler) {
+			defer wg.Done()
+			fun(config, key, f)
+		}(key, f)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
This PR refactors the livefuzzer a lot in order to make it easier to maintain and extend.
It does not change the interface significantly except for adding a `--gaslimit` flag and removing the send command 