### PR TITLE
Replace hardcoded tx costs with a call to eth_estimateGas

### DIFF
--- a/spammer/addresslist.go
+++ b/spammer/addresslist.go
@@ -148,7 +148,7 @@ func CreateAddresses(N int) ([]string, []string) {
 func Airdrop(config *Config, value *big.Int) error {
 	backend := ethclient.NewClient(config.backend)
 	sender := crypto.PubkeyToAddress(config.faucet.PublicKey)
-	fmt.Printf("airdrop faucet is at %x\n", sender)
+	fmt.Printf("Airdrop faucet is at %x\n", sender)
 	var tx *types.Transaction
 	chainid, err := backend.ChainID(context.Background())
 	if err != nil {

--- a/transactions.go
+++ b/transactions.go
@@ -106,7 +106,7 @@ func RandomValidTx(rpc *rpc.Client, f *filler.Filler, sender common.Address, non
 	gas, err := backend.EstimateGas(context.Background(), ethereum.CallMsg{
 		From:       sender,
 		To:         txref.To(),
-		Gas:        math.MaxUint16,
+		Gas:        math.MaxUint64,
 		GasPrice:   txref.GasPrice(),
 		GasFeeCap:  txref.GasFeeCap(),
 		GasTipCap:  txref.GasTipCap(),


### PR DESCRIPTION
When using tx-fuzz on the verkle testnet, we found some issues caused by the change in the gas schedule. Transactions now have to pay for the witness costs, so call `estimateGas` in order to find out what the price of a transaction is going to be, before sending it.

Creating this PR as a draft as there is still an open question (see comment).